### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index]
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
     @items = Item.includes(:user).order('created_at DESC')

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,11 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    @items = Item.includes(:user).order("created_at DESC")
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def new
@@ -22,12 +22,10 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
-
   private
 
   def item_params
     params.require(:item).permit(:name, :image, :price, :description, :status_id, :shipping_cost_id, :prefecture_id,
                                  :shipping_day_id, :category_id).merge(user_id: current_user.id)
   end
-
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,7 +128,7 @@
     <% if @items.any? %>
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to item_path:(item.id) do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -97,9 +97,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,9 +26,10 @@
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-    <% end %>
+    <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <%end%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
     <div class="item-explain-box">
       <span><%= @item.description %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-    <% else %>
+    <% elsif user_signed_in? && current_user.id != @item.user.id %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <%end%>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -44,27 +44,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,14 +16,15 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price%>
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.shipping_cost.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <%# if user_signed_in? && current_user.id == @item.user.id %>
 
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -22,23 +22,16 @@
         <%= @item.shipping_cost.name %>
       </span>
     </div>
-
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-    <%# if user_signed_in? && current_user.id == @item.user.id %>
-
+    <% if user_signed_in? && current_user.id == @item.user.id %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
+    <% end %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -104,7 +97,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -101,3 +101,4 @@
 </div>
 
 <%= render "shared/footer" %>
+

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -3,9 +3,9 @@ FactoryBot.define do
     name { Faker::Name.name }
     description { 'サンプル説明です' }
     category_id { Faker::Number.between(from: 2, to: 11) }
-    status_id { Faker::Number.between(from: 2, to: 7)}
-    shipping_cost_id { Faker::Number.between(from: 2, to: 3)}
-    prefecture_id { Faker::Number.between(from: 2, to: 48)}
+    status_id { Faker::Number.between(from: 2, to: 7) }
+    shipping_cost_id { Faker::Number.between(from: 2, to: 3) }
+    prefecture_id { Faker::Number.between(from: 2, to: 48) }
     shipping_day_id { Faker::Number.between(from: 2, to: 4) }
     price { 1000 }
     association :user

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include('Price is not included in the list')
       end
       it 'priceが10,000,000円以上だと投稿できない' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
         expect(@item.errors.full_messages).to include('Price is not included in the list')
       end
@@ -51,7 +51,7 @@ RSpec.describe Item, type: :model do
       it 'status_idが---のときは投稿できない' do
         @item.status_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Status is not included in the list")
+        expect(@item.errors.full_messages).to include('Status is not included in the list')
       end
       it 'shipping_cost_idが空のときは投稿できない' do
         @item.shipping_cost_id = ''
@@ -61,7 +61,7 @@ RSpec.describe Item, type: :model do
       it 'shipping_cost_idが---のときは投稿できない' do
         @item.shipping_cost_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping cost is not included in the list")
+        expect(@item.errors.full_messages).to include('Shipping cost is not included in the list')
       end
       it 'prefecture_idが空のときは投稿できない' do
         @item.prefecture_id = ''
@@ -71,7 +71,7 @@ RSpec.describe Item, type: :model do
       it 'prefecture_idが---のときは投稿できない' do
         @item.prefecture_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture is not included in the list")
+        expect(@item.errors.full_messages).to include('Prefecture is not included in the list')
       end
       it 'shipping_day_idが空のときは投稿できない' do
         @item.shipping_day_id = ''
@@ -81,7 +81,7 @@ RSpec.describe Item, type: :model do
       it 'shipping_day_idが---のときは投稿できない' do
         @item.shipping_day_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping day is not included in the list")
+        expect(@item.errors.full_messages).to include('Shipping day is not included in the list')
       end
       it 'category_idが空のときは投稿できない' do
         @item.category_id = ''
@@ -91,7 +91,7 @@ RSpec.describe Item, type: :model do
       it 'category_idが---のときは投稿できない' do
         @item.category_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category is not included in the list")
+        expect(@item.errors.full_messages).to include('Category is not included in the list')
       end
       it 'imageが空のときは投稿できない' do
         @item.image = nil


### PR DESCRIPTION
# what
商品詳細ページを実装した

# why
詳細を表示し、編集・削除・購入の機能へ進めるようにするため

【ログアウト状態】
（ログアウト状態でも詳細ページへ遷移できる、購入ボタンは非表示）
https://gyazo.com/eaa24bccd7f31d77148886120411655c

【ログイン状態】
（ログインユーザーと投稿者が同じなら編集・削除ボタンを表示）
https://gyazo.com/d8f35660ecb49886d116dadb64a83023

（ログインユーザーと投稿者が異なる場合は購入ボタンを表示）
https://gyazo.com/d8f35660ecb49886d116dadb64a83023
